### PR TITLE
Add DOCX text extraction and document supported formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ A program that utilizes OCR, NLP, and compares hashes of files and folders to lo
 - Progress updates
 - Multithreading for efficient file processing
 
+## Supported File Types
+- Images (`.png`, `.jpg`, `.jpeg`)
+- PDF documents (`.pdf`)
+- Word documents (`.docx`)
+- Plain text files and other text-based formats
+
 ## Requirements
 - Python 3.12
 - Required libraries (see `requirements.txt`)
@@ -20,6 +26,7 @@ A program that utilizes OCR, NLP, and compares hashes of files and folders to lo
 3. Install required libraries:
    ```bash
    pip install -r requirements.txt
+   ```
 
 ## Usage
 Run the script with the following command:

--- a/file_organizer.py
+++ b/file_organizer.py
@@ -10,6 +10,7 @@ import concurrent.futures
 import pytesseract
 from PIL import Image
 from PyPDF2 import PdfReader
+from docx import Document
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.naive_bayes import MultinomialNB
 from logging.handlers import RotatingFileHandler
@@ -124,6 +125,11 @@ def extract_text(file_path):
                 for page_num in range(len(reader.pages)):
                     page = reader.pages[page_num]
                     text += page.extract_text()
+        elif file_path.lower().endswith('.docx'):
+            text = ""
+            document = Document(file_path)
+            for paragraph in document.paragraphs:
+                text += paragraph.text + "\n"
         else:
             with open(file_path, 'r', errors='ignore') as file:
                 text = file.read()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pypdf>=3.9.0
 tqdm==4.66.3
 scikit-learn>=1.5.0
 numpy>=1.22.0
+python-docx==0.8.11
 
 


### PR DESCRIPTION
## Summary
- add `python-docx` dependency for Word document parsing
- handle `.docx` files in `extract_text`
- document supported file types in README

## Testing
- `python -m py_compile file_organizer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ecd1a190832a9e26805ffcce00e4