### PR TITLE
Persist text classifier and add training script

### DIFF
--- a/file_organizer.py
+++ b/file_organizer.py
@@ -10,8 +10,7 @@ import concurrent.futures
 import pytesseract
 from PIL import Image
 from PyPDF2 import PdfReader
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.naive_bayes import MultinomialNB
+from joblib import load
 from logging.handlers import RotatingFileHandler
 from nltk.tokenize import word_tokenize
 
@@ -59,14 +58,17 @@ def compute_hash(file_path):
         logging.error(f'Error computing hash for file {file_path}: {e}')
     return hash_algo.hexdigest()
 
-# Train a placeholder text classifier (to be replaced with a real model)
-def train_text_classifier():
-    # This is a placeholder. In a real scenario, you'd load a pre-trained model.
-    vectorizer = TfidfVectorizer()
-    model = MultinomialNB()
-    return vectorizer, model
+# Load pre-trained text classifier
+def load_text_classifier():
+    try:
+        vectorizer = load('vectorizer.joblib')
+        model = load('model.joblib')
+        return vectorizer, model
+    except FileNotFoundError:
+        logging.error('Model files not found. Please run train_model.py before organizing files.')
+        raise
 
-vectorizer, model = train_text_classifier()
+vectorizer, model = load_text_classifier()
 
 # Categorize file based on content
 def categorize_file(file_name, file_content):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pypdf>=3.9.0
 tqdm==4.66.3
 scikit-learn>=1.5.0
 numpy>=1.22.0
+joblib>=1.3.0
 
 

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,51 @@
+import json
+import nltk
+from nltk.tokenize import word_tokenize
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.naive_bayes import MultinomialNB
+from joblib import dump
+
+
+def load_categories():
+    """Load categories from categories.json or return defaults."""
+    try:
+        with open('categories.json', 'r') as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {
+            'academic': ['research', 'thesis', 'paper', 'study'],
+            'finance': ['invoice', 'receipt', 'bank', 'statement'],
+            'developer': ['code', 'script', 'program', 'software'],
+            'personal': ['photo', 'music', 'video', 'diary'],
+            'business': ['contract', 'agreement', 'proposal', 'report'],
+        }
+
+
+def prepare_dataset(categories):
+    texts = []
+    labels = []
+    for label, keywords in categories.items():
+        for keyword in keywords:
+            texts.append(keyword)
+            labels.append(label)
+    return texts, labels
+
+
+def train_and_save():
+    nltk.download('punkt', quiet=True)
+    nltk.download('punkt_tab', quiet=True)
+    categories = load_categories()
+    texts, labels = prepare_dataset(categories)
+
+    vectorizer = TfidfVectorizer(tokenizer=word_tokenize)
+    X = vectorizer.fit_transform(texts)
+
+    model = MultinomialNB()
+    model.fit(X, labels)
+
+    dump(vectorizer, 'vectorizer.joblib')
+    dump(model, 'model.joblib')
+
+
+if __name__ == '__main__':
+    train_and_save()


### PR DESCRIPTION
## Summary
- add `train_model.py` to generate a TF-IDF + MultinomialNB model and save artifacts with joblib
- load pre-trained vectorizer and classifier in `file_organizer.py`
- document joblib dependency in `requirements.txt`

## Testing
- `python train_model.py`
- `python - <<'PY'
import file_organizer
print(file_organizer.categorize_file('sample.txt', 'This research paper and thesis'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b4ecbd8580832aa857e09b7864169c