### PR TITLE
Add category management CLI and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A program that utilizes OCR, NLP, and compares hashes of files and folders to lo
 3. Install required libraries:
    ```bash
    pip install -r requirements.txt
+   ```
 
 ## Usage
 Run the script with the following command:
@@ -31,6 +32,26 @@ python file_organizer.py --source /path/to/source_directory --duplicates /path/t
 ### Configuration
 Categories can be modified in the categories.json file.
 Logs are stored in file_organizer.log.
+
+### Managing Categories
+Use `manage_categories.py` to view or edit the available categories:
+
+```bash
+python manage_categories.py list
+```
+
+Add a new category or keywords:
+
+```bash
+python manage_categories.py add finance invoice receipt
+```
+
+Remove a keyword or an entire category:
+
+```bash
+python manage_categories.py remove finance receipt
+```
+
 
 ### Contact
 For any issues or suggestions, please contact [tea.larson-hetrick@waldenu.edu](mailto:tea.larson-hetrick@waldenu.edu).

--- a/manage_categories.py
+++ b/manage_categories.py
@@ -1,0 +1,74 @@
+import argparse
+from file_organizer import load_categories, save_categories
+
+
+def list_categories(_):
+    """Print all categories and their keywords."""
+    categories = load_categories()
+    for category, keywords in categories.items():
+        print(f"{category}: {', '.join(keywords)}")
+
+
+def add_category(args):
+    """Add a new category or keywords to an existing category."""
+    categories = load_categories()
+    cat = args.category.lower()
+    keywords = [k.lower() for k in args.keywords]
+
+    if cat in categories:
+        existing = set(categories[cat])
+        categories[cat].extend([k for k in keywords if k not in existing])
+    else:
+        categories[cat] = keywords
+
+    save_categories(categories)
+    print(f"Category '{cat}' updated.")
+
+
+def remove_category(args):
+    """Remove keywords from a category or delete the category."""
+    categories = load_categories()
+    cat = args.category.lower()
+
+    if cat not in categories:
+        print(f"Category '{cat}' not found.")
+        return
+
+    if args.keywords:
+        keywords_to_remove = {k.lower() for k in args.keywords}
+        categories[cat] = [k for k in categories[cat] if k not in keywords_to_remove]
+        if categories[cat]:
+            print(f"Updated category '{cat}'.")
+        else:
+            del categories[cat]
+            print(f"Category '{cat}' removed.")
+    else:
+        del categories[cat]
+        print(f"Category '{cat}' removed.")
+
+    save_categories(categories)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage categories in categories.json")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parser_add = subparsers.add_parser("add", help="Add a category or keywords")
+    parser_add.add_argument("category", help="Category name")
+    parser_add.add_argument("keywords", nargs="*", help="Keywords for the category")
+    parser_add.set_defaults(func=add_category)
+
+    parser_remove = subparsers.add_parser("remove", help="Remove a category or keywords")
+    parser_remove.add_argument("category", help="Category name")
+    parser_remove.add_argument("keywords", nargs="*", help="Keywords to remove")
+    parser_remove.set_defaults(func=remove_category)
+
+    parser_list = subparsers.add_parser("list", help="List all categories")
+    parser_list.set_defaults(func=list_categories)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `manage_categories.py` CLI for listing, adding, and removing entries in `categories.json`
- document category management commands in README

## Testing
- `python manage_categories.py --help`
- `python manage_categories.py list`


------
https://chatgpt.com/codex/tasks/task_e_68b4ecc2e2d4832a807a01e42e9244b0