### PR TITLE
Expose worker thread count via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,21 @@ A program that utilizes OCR, NLP, and compares hashes of files and folders to lo
 3. Install required libraries:
    ```bash
    pip install -r requirements.txt
+   ```
 
 ## Usage
 Run the script with the following command:
 
 ```bash
-python file_organizer.py --source /path/to/source_directory --duplicates /path/to/duplicates_directory
+python file_organizer.py --source /path/to/source_directory --duplicates /path/to/duplicates_directory [--workers 4]
 ```
 
 ### Configuration
 Categories can be modified in the categories.json file.
 Logs are stored in file_organizer.log.
+
+### Performance
+The `--workers` option controls how many files are processed in parallel. Increasing the number can speed up processing on multi-core systems but uses more CPU resources. Decreasing it reduces resource usage at the cost of slower performance.
 
 ### Contact
 For any issues or suggestions, please contact [tea.larson-hetrick@waldenu.edu](mailto:tea.larson-hetrick@waldenu.edu).

--- a/file_organizer.py
+++ b/file_organizer.py
@@ -177,10 +177,10 @@ def process_file(file_path, duplicates_dir):
     except Exception as e:
         logging.error(f'Error processing file {file_path}: {e}')
 
-def process_directory(directory, duplicates_dir):
+def process_directory(directory, duplicates_dir, workers=4):
     total_files = sum([len(files) for r, d, files in os.walk(directory)])
     with tqdm(total=total_files, desc="Processing files") as pbar:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
             futures = []
             for root, _, files in os.walk(directory):
                 for file_name in files:
@@ -197,13 +197,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='File Organizer Script')
     parser.add_argument('--source', required=True, help='Path to the source directory')
     parser.add_argument('--duplicates', required=True, help='Path to the duplicates directory')
+    parser.add_argument('--workers', type=int, default=4, help='Number of worker threads for processing files')
     args = parser.parse_args()
 
     source_directory = args.source
     duplicates_directory = args.duplicates
+    workers = args.workers
 
     if not os.path.exists(review_later_folder):
         os.makedirs(review_later_folder)
 
-    process_directory(source_directory, duplicates_directory)
+    process_directory(source_directory, duplicates_directory, workers)
     logging.info('File organization completed')


### PR DESCRIPTION
## Summary
- Allow custom worker thread count in `process_directory` and command-line interface
- Document `--workers` option and its performance impact in README

## Testing
- `python -m py_compile file_organizer.py`
- `python file_organizer.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b4ecd0a550832a9324d7213a986099